### PR TITLE
Add Discord Integration

### DIFF
--- a/.github/workflows/mac-auto-build-release.yml
+++ b/.github/workflows/mac-auto-build-release.yml
@@ -42,7 +42,7 @@ jobs:
             runner: macos-15
             arch: arm64
           - name: Intel
-            runner: macos-13
+            runner: macos-15-intel
             arch: x86_64
     steps:
       - name: Checkout Arduino-Source

--- a/.github/workflows/mac-auto-build-release.yml
+++ b/.github/workflows/mac-auto-build-release.yml
@@ -64,6 +64,13 @@ jobs:
           version: ${{ github.event.inputs.qt_version }}
           modules: 'qtmultimedia qtserialport'
 
+      - name: Install DPP v10.0.22
+        run: |
+          BREW_PREFIX=$(brew --prefix)
+          brew tap-new --no-git runner/libdpp
+          cp Arduino-Source/3rdPartyBinaries/libdpp@10.0.22.rb $BREW_PREFIX/Library/Taps/runner/homebrew-libdpp/Formula/
+          brew install libdpp@10.0.22
+
       - name: Build SerialPrograms.app
         run: |
           cd Arduino-Source/SerialPrograms

--- a/.github/workflows/mac-auto-build-release.yml
+++ b/.github/workflows/mac-auto-build-release.yml
@@ -64,17 +64,14 @@ jobs:
           version: ${{ github.event.inputs.qt_version }}
           modules: 'qtmultimedia qtserialport'
 
-      - name: Install DPP v10.0.22
+      - name: Install DPP v10.0.28
         run: |
           BREW_PREFIX=$(brew --prefix)
           brew tap-new --no-git runner/libdpp
-          if [ "${{ matrix.arch }}" = "arm64" ]; then
-            TAP_PATH="$BREW_PREFIX/Library/Taps/runner/homebrew-libdpp/Formula/"
-          else
-            TAP_PATH="$BREW_PREFIX/Homebrew/Library/Taps/runner/homebrew-libdpp/Formula/"
-          fi
-          cp Arduino-Source/3rdPartyBinaries/libdpp@10.0.22.rb "$TAP_PATH"
-          brew install libdpp@10.0.22
+          FORMULA_DIR="$(brew --repo PA/libdpp)/Formula"
+          mkdir -p "$FORMULA_DIR"
+          cp Arduino-Source/3rdPartyBinaries/libdpp@10.0.28.rb "$FORMULA_DIR/"
+          brew install libdpp@10.0.28
 
       - name: Build SerialPrograms.app
         run: |

--- a/.github/workflows/mac-auto-build-release.yml
+++ b/.github/workflows/mac-auto-build-release.yml
@@ -68,7 +68,12 @@ jobs:
         run: |
           BREW_PREFIX=$(brew --prefix)
           brew tap-new --no-git runner/libdpp
-          cp Arduino-Source/3rdPartyBinaries/libdpp@10.0.22.rb $BREW_PREFIX/Library/Taps/runner/homebrew-libdpp/Formula/
+          if [ "${{ matrix.arch }}" = "arm64" ]; then
+            TAP_PATH="$BREW_PREFIX/Library/Taps/runner/homebrew-libdpp/Formula/"
+          else
+            TAP_PATH="$BREW_PREFIX/Homebrew/Library/Taps/runner/homebrew-libdpp/Formula/"
+          fi
+          cp Arduino-Source/3rdPartyBinaries/libdpp@10.0.22.rb "$TAP_PATH"
           brew install libdpp@10.0.22
 
       - name: Build SerialPrograms.app


### PR DESCRIPTION
Install, compile, and bundle DPP to enable Discord Integration for MacOS distributable