### PR TITLE
Change to macos-15-intel

### DIFF
--- a/.github/workflows/mac-auto-build-release.yml
+++ b/.github/workflows/mac-auto-build-release.yml
@@ -42,7 +42,7 @@ jobs:
             runner: macos-15
             arch: arm64
           - name: Intel
-            runner: macos-13
+            runner: macos-15-intel
             arch: x86_64
     steps:
       - name: Checkout Arduino-Source


### PR DESCRIPTION
Apparently I accidentally reverted the version back to macos-13 before committing which was exposed due to the brownout period. Oops, fixing it here